### PR TITLE
Fix how the dotfile directory gets symlinked

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,2 +1,7 @@
-gem install --no-ri --no-rdoc puppet
-FACTER_homedir=~ puppet apply site.pp
+#!/usr/bin/env bash
+
+#gem install --no-ri --no-rdoc puppet
+
+# http://stackoverflow.com/questions/59895/getting-the-current-present-working-directory-of-a-bash-script-from-within-the-s
+dotfiles_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+FACTER_home_dir=~ FACTER_dotfiles_dir=$dotfiles_dir puppet apply site.pp

--- a/site.pp
+++ b/site.pp
@@ -1,4 +1,4 @@
-file { "$homedir/.bash_profile":
+file { "${home_dir}/.bash_profile":
   ensure => 'link',
-  target => "$homedir/code/dot_files/.bash_profile",
+  target => "${dotfiles_dir}/.bash_profile",
 }


### PR DESCRIPTION
  The dot_file directory was initially hardcoded.
  Be smart about how it is detected and configure
  based on the parent directory of bootstrap.sh